### PR TITLE
Adapted severity levels to our logging needs

### DIFF
--- a/console.go
+++ b/console.go
@@ -320,21 +320,28 @@ func consoleDefaultFormatLevel(noColor bool) Formatter {
 	return func(i interface{}) string {
 		var l string
 		if ll, ok := i.(string); ok {
-			switch ll {
-			case "trace":
+			lvl, err := ParseLevel(ll)
+			if err != nil {
+				l = colorize("???", colorBold, noColor)
+			}
+
+			switch lvl {
+			case TraceLevel:
 				l = colorize("TRC", colorMagenta, noColor)
-			case "debug":
+			case DebugLevel:
 				l = colorize("DBG", colorYellow, noColor)
-			case "info":
+			case InfoLevel:
 				l = colorize("INF", colorGreen, noColor)
-			case "warn":
+			case WarnLevel:
 				l = colorize("WRN", colorRed, noColor)
-			case "error":
+			case NotifyLevel:
+				l = colorize("NTF", colorRed, noColor)
+			case ErrorLevel:
 				l = colorize(colorize("ERR", colorRed, noColor), colorBold, noColor)
-			case "fatal":
-				l = colorize(colorize("FTL", colorRed, noColor), colorBold, noColor)
-			case "panic":
-				l = colorize(colorize("PNC", colorRed, noColor), colorBold, noColor)
+			case CriticalLevel:
+				l = colorize(colorize("CRT", colorRed, noColor), colorBold, noColor)
+			case AlertLevel:
+				l = colorize(colorize("ALR", colorRed, noColor), colorBold, noColor)
 			default:
 				l = colorize("???", colorBold, noColor)
 			}

--- a/hook.go
+++ b/hook.go
@@ -17,7 +17,7 @@ func (h HookFunc) Run(e *Event, level Level, message string) {
 
 // LevelHook applies a different hook for each level.
 type LevelHook struct {
-	NoLevelHook, TraceHook, DebugHook, InfoHook, WarnHook, ErrorHook, FatalHook, PanicHook Hook
+	NoLevelHook, TraceHook, DebugHook, InfoHook, WarnHook, NotifyHook, ErrorHook, CriticalHook, AlertHook Hook
 }
 
 // Run implements the Hook interface.
@@ -39,17 +39,21 @@ func (h LevelHook) Run(e *Event, level Level, message string) {
 		if h.WarnHook != nil {
 			h.WarnHook.Run(e, level, message)
 		}
+	case NotifyLevel:
+		if h.NotifyHook != nil {
+			h.NotifyHook.Run(e, level, message)
+		}
 	case ErrorLevel:
 		if h.ErrorHook != nil {
 			h.ErrorHook.Run(e, level, message)
 		}
-	case FatalLevel:
-		if h.FatalHook != nil {
-			h.FatalHook.Run(e, level, message)
+	case CriticalLevel:
+		if h.CriticalHook != nil {
+			h.CriticalHook.Run(e, level, message)
 		}
-	case PanicLevel:
-		if h.PanicHook != nil {
-			h.PanicHook.Run(e, level, message)
+	case AlertLevel:
+		if h.AlertHook != nil {
+			h.AlertHook.Run(e, level, message)
 		}
 	case NoLevel:
 		if h.NoLevelHook != nil {

--- a/journald/journald.go
+++ b/journald/journald.go
@@ -56,11 +56,13 @@ func levelToJPrio(zLevel string) journal.Priority {
 		return journal.PriInfo
 	case zerolog.WarnLevel:
 		return journal.PriWarning
+	case zerolog.NotifyLevel:
+		return journal.PriWarning
 	case zerolog.ErrorLevel:
 		return journal.PriErr
-	case zerolog.FatalLevel:
+	case zerolog.CriticalLevel:
 		return journal.PriCrit
-	case zerolog.PanicLevel:
+	case zerolog.AlertLevel:
 		return journal.PriEmerg
 	case zerolog.NoLevel:
 		return journal.PriNotice

--- a/log/log.go
+++ b/log/log.go
@@ -73,6 +73,13 @@ func Warn() *zerolog.Event {
 	return Logger.Warn()
 }
 
+// Notify starts a new message with notify level.
+//
+// You must call Msg on the returned event in order to send the event.
+func Notify() *zerolog.Event {
+	return Logger.Notify()
+}
+
 // Error starts a new message with error level.
 //
 // You must call Msg on the returned event in order to send the event.
@@ -80,20 +87,18 @@ func Error() *zerolog.Event {
 	return Logger.Error()
 }
 
-// Fatal starts a new message with fatal level. The os.Exit(1) function
-// is called by the Msg method.
+// Critical starts a new message with critical level.
 //
 // You must call Msg on the returned event in order to send the event.
-func Fatal() *zerolog.Event {
-	return Logger.Fatal()
+func Critical() *zerolog.Event {
+	return Logger.Critical()
 }
 
-// Panic starts a new message with panic level. The message is also sent
-// to the panic function.
+// Alert starts a new message with panic level.
 //
 // You must call Msg on the returned event in order to send the event.
-func Panic() *zerolog.Event {
-	return Logger.Panic()
+func Alert() *zerolog.Event {
+	return Logger.Alert()
 }
 
 // WithLevel starts a new message with level.

--- a/log/log_example_test.go
+++ b/log/log_example_test.go
@@ -106,17 +106,17 @@ func ExampleError() {
 }
 
 // Example of a log at a particular "level" (in this case, "fatal")
-func ExampleFatal() {
+func ExampleCritical() {
 	setup()
 	err := errors.New("A repo man spends his life getting into tense situations")
 	service := "myservice"
 
-	log.Fatal().
+	log.Critical().
 		Err(err).
 		Str("service", service).
 		Msgf("Cannot start %s", service)
 
-	// Outputs: {"level":"fatal","time":1199811905,"error":"A repo man spends his life getting into tense situations","service":"myservice","message":"Cannot start myservice"}
+	// Outputs: {"level":"critical","time":1199811905,"error":"A repo man spends his life getting into tense situations","service":"myservice","message":"Cannot start myservice"}
 }
 
 // TODO: Panic

--- a/log_test.go
+++ b/log_test.go
@@ -429,9 +429,9 @@ func TestLevel(t *testing.T) {
 		}
 	})
 
-	t.Run("NoLevel/Panic", func(t *testing.T) {
+	t.Run("NoLevel/Critical", func(t *testing.T) {
 		out := &bytes.Buffer{}
-		log := New(out).Level(PanicLevel)
+		log := New(out).Level(CriticalLevel)
 		log.Log().Msg("test")
 		if got, want := decodeIfBinaryToString(out.Bytes()), `{"message":"test"}`+"\n"; got != want {
 			t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
@@ -462,9 +462,10 @@ func TestGetLevel(t *testing.T) {
 		DebugLevel,
 		InfoLevel,
 		WarnLevel,
+		NotifyLevel,
 		ErrorLevel,
-		FatalLevel,
-		PanicLevel,
+		CriticalLevel,
+		AlertLevel,
 		NoLevel,
 		Disabled,
 	}

--- a/syslog.go
+++ b/syslog.go
@@ -63,12 +63,14 @@ func (sw syslogWriter) WriteLevel(level Level, p []byte) (n int, err error) {
 		err = sw.w.Info(sw.prefix + string(p))
 	case WarnLevel:
 		err = sw.w.Warning(sw.prefix + string(p))
+	case NotifyLevel:
+		err = sw.w.Warning(sw.prefix + string(p))
 	case ErrorLevel:
 		err = sw.w.Err(sw.prefix + string(p))
-	case FatalLevel:
-		err = sw.w.Emerg(sw.prefix + string(p))
-	case PanicLevel:
+	case CriticalLevel:
 		err = sw.w.Crit(sw.prefix + string(p))
+	case AlertLevel:
+		err = sw.w.Emerg(sw.prefix + string(p))
 	case NoLevel:
 		err = sw.w.Info(sw.prefix + string(p))
 	default:


### PR DESCRIPTION
The objective of this PR is to adapt zerolog levels to our levels. In general it's a straightforward change, but here are some notes:

* I decided to keep the levels `NoLevel` and `Disabled` to make the minimum amount of changes and also to keep the compatibility with zerolog
* In zerolog, the levels `Fatal` and `Panic` terminate the application. Those levels are now `Critical` and `Alert` and they don't kill the application
* `ConsoleWriter` now uses the levels defined instead of strings (for the level formatter)  