### PR TITLE
Further improvements

### DIFF
--- a/array.go
+++ b/array.go
@@ -67,6 +67,13 @@ func (a *Array) Object(obj LogObjectMarshaler) *Array {
 	return a
 }
 
+// Event appends an event to the array.
+func (a *Array) Event(event *Event) *Array {
+	buf := enc.AppendEndMarker(event.buf)
+	a.buf = append(enc.AppendArrayDelim(a.buf), buf...)
+	return a
+}
+
 // Str append append the val as a string to the array.
 func (a *Array) Str(val string) *Array {
 	a.buf = enc.AppendString(enc.AppendArrayDelim(a.buf), val)

--- a/console.go
+++ b/console.go
@@ -57,14 +57,15 @@ type ConsoleWriter struct {
 	// PartsOrder defines the order of parts in output.
 	PartsOrder []string
 
-	FormatTimestamp     Formatter
-	FormatLevel         Formatter
-	FormatCaller        Formatter
-	FormatMessage       Formatter
-	FormatFieldName     Formatter
-	FormatFieldValue    Formatter
-	FormatErrFieldName  Formatter
-	FormatErrFieldValue Formatter
+	FormatTimestamp         Formatter
+	FormatLevel             Formatter
+	FormatLevelAbbreviation Formatter
+	FormatCaller            Formatter
+	FormatMessage           Formatter
+	FormatFieldName         Formatter
+	FormatFieldValue        Formatter
+	FormatErrFieldName      Formatter
+	FormatErrFieldValue     Formatter
 }
 
 // NewConsoleWriter creates and initializes a new ConsoleWriter.
@@ -210,8 +211,13 @@ func (w ConsoleWriter) writePart(buf *bytes.Buffer, evt map[string]interface{}, 
 
 	switch p {
 	case LevelFieldName:
+		levelAbbreviator := consoleDefaultFormatLevelAbbreviation()
+		if w.FormatLevelAbbreviation != nil {
+			levelAbbreviator = w.FormatLevelAbbreviation
+		}
+
 		if w.FormatLevel == nil {
-			f = consoleDefaultFormatLevel(w.NoColor)
+			f = consoleDefaultFormatLevel(w.NoColor, levelAbbreviator)
 		} else {
 			f = w.FormatLevel
 		}
@@ -316,43 +322,83 @@ func consoleDefaultFormatTimestamp(timeFormat string, noColor bool) Formatter {
 	}
 }
 
-func consoleDefaultFormatLevel(noColor bool) Formatter {
+func consoleDefaultFormatLevel(noColor bool, levelAbbreviator Formatter) Formatter {
 	return func(i interface{}) string {
 		var l string
 		if ll, ok := i.(string); ok {
 			lvl, err := ParseLevel(ll)
 			if err != nil {
-				l = colorize("???", colorBold, noColor)
+				l = colorize(levelAbbreviator(ll), colorBold, noColor)
 			}
 
 			switch lvl {
-			case TraceLevel:
-				l = colorize("TRC", colorMagenta, noColor)
 			case DebugLevel:
-				l = colorize("DBG", colorYellow, noColor)
+				l = colorize(levelAbbreviator(lvl), colorYellow, noColor)
+			case TraceLevel:
+				l = colorize(levelAbbreviator(lvl), colorMagenta, noColor)
 			case InfoLevel:
-				l = colorize("INF", colorGreen, noColor)
+				l = colorize(levelAbbreviator(lvl), colorGreen, noColor)
 			case WarnLevel:
-				l = colorize("WRN", colorRed, noColor)
+				l = colorize(levelAbbreviator(lvl), colorRed, noColor)
 			case NotifyLevel:
-				l = colorize("NTF", colorRed, noColor)
+				l = colorize(levelAbbreviator(lvl), colorRed, noColor)
 			case ErrorLevel:
-				l = colorize(colorize("ERR", colorRed, noColor), colorBold, noColor)
+				l = colorize(colorize(levelAbbreviator(lvl), colorRed, noColor), colorBold, noColor)
 			case CriticalLevel:
-				l = colorize(colorize("CRT", colorRed, noColor), colorBold, noColor)
+				l = colorize(colorize(levelAbbreviator(lvl), colorRed, noColor), colorBold, noColor)
 			case AlertLevel:
-				l = colorize(colorize("ALR", colorRed, noColor), colorBold, noColor)
+				l = colorize(colorize(levelAbbreviator(lvl), colorRed, noColor), colorBold, noColor)
 			default:
-				l = colorize("???", colorBold, noColor)
+				l = colorize(levelAbbreviator(lvl), colorBold, noColor)
 			}
 		} else {
 			if i == nil {
-				l = colorize("???", colorBold, noColor)
+				l = colorize(levelAbbreviator(i), colorBold, noColor)
 			} else {
-				l = strings.ToUpper(fmt.Sprintf("%s", i))[0:3]
+				l = levelAbbreviator(i)
 			}
 		}
 		return l
+	}
+}
+
+func consoleDefaultFormatLevelAbbreviation() Formatter {
+	return func(i interface{}) string {
+
+		if i == nil {
+			return "???"
+		}
+
+		if _, ok := i.(string); ok {
+			// This case corresponds with a non-level string
+			return "???"
+		}
+
+		if level, ok := i.(Level); ok {
+			switch level {
+			case DebugLevel:
+				return "DBG"
+			case TraceLevel:
+				return "TRC"
+			case InfoLevel:
+				return "INF"
+			case WarnLevel:
+				return "WRN"
+			case NotifyLevel:
+				return "NTF"
+			case ErrorLevel:
+				return "ERR"
+			case CriticalLevel:
+				return "CRT"
+			case AlertLevel:
+				return "ALR"
+			default:
+				return "???"
+			}
+		}
+
+		// a non-nil interface, that is not a Level
+		return strings.ToUpper(fmt.Sprintf("%s", i))[0:3]
 	}
 }
 
@@ -400,16 +446,5 @@ func consoleDefaultFormatErrFieldName(noColor bool) Formatter {
 func consoleDefaultFormatErrFieldValue(noColor bool) Formatter {
 	return func(i interface{}) string {
 		return colorize(fmt.Sprintf("%s", i), colorRed, noColor)
-	}
-}
-
-func HideNoLevelFormatter(noColor bool) Formatter {
-	return func(i interface{}) string {
-		if i == nil {
-			return ""
-		}
-
-		defaultFormatter := consoleDefaultFormatLevel(noColor)
-		return defaultFormatter(i)
 	}
 }

--- a/console.go
+++ b/console.go
@@ -402,3 +402,14 @@ func consoleDefaultFormatErrFieldValue(noColor bool) Formatter {
 		return colorize(fmt.Sprintf("%s", i), colorRed, noColor)
 	}
 }
+
+func HideNoLevelFormatter(noColor bool) Formatter {
+	return func(i interface{}) string {
+		if i == nil {
+			return ""
+		}
+
+		defaultFormatter := consoleDefaultFormatLevel(noColor)
+		return defaultFormatter(i)
+	}
+}

--- a/console_test.go
+++ b/console_test.go
@@ -35,8 +35,8 @@ func ExampleNewConsoleWriter() {
 	out.NoColor = true // For testing purposes only
 	log := zerolog.New(out)
 
-	log.Debug().Str("foo", "bar").Msg("Hello World")
-	// Output: <nil> DBG Hello World foo=bar
+	log.Trace().Str("foo", "bar").Msg("Hello World")
+	// Output: <nil> TRC Hello World foo=bar
 }
 
 func ExampleNewConsoleWriter_customFormatters() {

--- a/diode/diode_example_test.go
+++ b/diode/diode_example_test.go
@@ -11,6 +11,11 @@ import (
 )
 
 func ExampleNewWriter() {
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
+
 	w := diode.NewWriter(os.Stdout, 1000, 0, func(missed int) {
 		fmt.Printf("Dropped %d messages\n", missed)
 	})

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 func TestNewWriter(t *testing.T) {
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
+
 	buf := bytes.Buffer{}
 	w := diode.NewWriter(&buf, 1000, 0, func(missed int) {
 		fmt.Printf("Dropped %d messages\n", missed)

--- a/hook_test.go
+++ b/hook_test.go
@@ -124,6 +124,11 @@ func TestHook(t *testing.T) {
 			log.Error().Msg("")
 		}},
 	}
+
+	globalLevel := GlobalLevel()
+	SetGlobalLevel(DebugLevel)
+	defer SetGlobalLevel(globalLevel)
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/log.go
+++ b/log.go
@@ -109,7 +109,7 @@ import (
 type Level int8
 
 const (
-	// DebugLevel defines debug log level.
+	// TraceLevel defines trace log level.
 	TraceLevel Level = iota
 	// InfoLevel defines info log level.
 	InfoLevel
@@ -128,7 +128,7 @@ const (
 	// Disabled disables the logger.
 	Disabled
 
-	// TraceLevel defines trace log level.
+	// DebugLevel defines debug log level.
 	DebugLevel Level = -1
 )
 

--- a/log.go
+++ b/log.go
@@ -110,7 +110,7 @@ type Level int8
 
 const (
 	// DebugLevel defines debug log level.
-	DebugLevel Level = iota
+	TraceLevel Level = iota
 	// InfoLevel defines info log level.
 	InfoLevel
 	// WarnLevel defines warn log level.
@@ -129,15 +129,15 @@ const (
 	Disabled
 
 	// TraceLevel defines trace log level.
-	TraceLevel Level = -1
+	DebugLevel Level = -1
 )
 
 func (l Level) String() string {
 	switch l {
-	case TraceLevel:
-		return "trace"
 	case DebugLevel:
 		return "debug"
+	case TraceLevel:
+		return "trace"
 	case InfoLevel:
 		return "info"
 	case WarnLevel:
@@ -160,10 +160,10 @@ func (l Level) String() string {
 // returns an error if the input string does not match known values.
 func ParseLevel(levelStr string) (Level, error) {
 	switch levelStr {
-	case LevelFieldMarshalFunc(TraceLevel):
-		return TraceLevel, nil
 	case LevelFieldMarshalFunc(DebugLevel):
 		return DebugLevel, nil
+	case LevelFieldMarshalFunc(TraceLevel):
+		return TraceLevel, nil
 	case LevelFieldMarshalFunc(InfoLevel):
 		return InfoLevel, nil
 	case LevelFieldMarshalFunc(WarnLevel):
@@ -210,7 +210,7 @@ func New(w io.Writer) Logger {
 	if !ok {
 		lw = levelWriterAdapter{w}
 	}
-	return Logger{w: lw, level: TraceLevel}
+	return Logger{w: lw, level: DebugLevel}
 }
 
 // Nop returns a disabled logger for which all operation are no-op.
@@ -360,10 +360,10 @@ func (l *Logger) Alert() *Event {
 // You must call Msg on the returned event in order to send the event.
 func (l *Logger) WithLevel(level Level) *Event {
 	switch level {
-	case TraceLevel:
-		return l.Trace()
 	case DebugLevel:
 		return l.Debug()
+	case TraceLevel:
+		return l.Trace()
 	case InfoLevel:
 		return l.Info()
 	case WarnLevel:

--- a/log/log_example_test.go
+++ b/log/log_example_test.go
@@ -33,6 +33,10 @@ func setup() {
 // Note that both Print and Printf are at the debug log level by default
 func ExamplePrint() {
 	setup()
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
 
 	log.Print("hello world")
 	// Output: {"level":"debug","time":1199811905,"message":"hello world"}
@@ -41,6 +45,10 @@ func ExamplePrint() {
 // Simple logging example using the Printf function in the log package
 func ExamplePrintf() {
 	setup()
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
 
 	log.Printf("hello %s", "world")
 	// Output: {"level":"debug","time":1199811905,"message":"hello world"}
@@ -75,6 +83,11 @@ func ExampleTrace() {
 
 // Example of a log at a particular "level" (in this case, "debug")
 func ExampleDebug() {
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
+	
 	setup()
 	log.Debug().Msg("hello world")
 

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -80,6 +80,11 @@ func ExampleLogger_Hook() {
 }
 
 func ExampleLogger_Print() {
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
+
 	log := zerolog.New(os.Stdout)
 
 	log.Print("hello world")
@@ -88,6 +93,11 @@ func ExampleLogger_Print() {
 }
 
 func ExampleLogger_Printf() {
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
+
 	log := zerolog.New(os.Stdout)
 
 	log.Printf("hello %s", "world")
@@ -107,6 +117,11 @@ func ExampleLogger_Trace() {
 }
 
 func ExampleLogger_Debug() {
+	// The default global level is Trace
+	globalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer zerolog.SetGlobalLevel(globalLevel)
+
 	log := zerolog.New(os.Stdout)
 
 	log.Debug().

--- a/log_test.go
+++ b/log_test.go
@@ -530,6 +530,11 @@ func TestLevelWriter(t *testing.T) {
 			p string
 		}{},
 	}
+
+	globalLevel := GlobalLevel()
+	SetGlobalLevel(DebugLevel)
+	defer SetGlobalLevel(globalLevel)
+
 	log := New(lw)
 	log.Trace().Msg("0")
 	log.Debug().Msg("1")
@@ -728,8 +733,8 @@ func TestLevelFieldMarshalFunc(t *testing.T) {
 	out := &bytes.Buffer{}
 	log := New(out)
 
-	log.Debug().Msg("test")
-	if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"DEBUG","message":"test"}`+"\n"; got != want {
+	log.Trace().Msg("test")
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"level":"TRACE","message":"test"}`+"\n"; got != want {
 		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
 	}
 	out.Reset()

--- a/syslog.go
+++ b/syslog.go
@@ -56,8 +56,7 @@ func (sw syslogWriter) Write(p []byte) (n int, err error) {
 // WriteLevel implements LevelWriter interface.
 func (sw syslogWriter) WriteLevel(level Level, p []byte) (n int, err error) {
 	switch level {
-	case TraceLevel:
-	case DebugLevel:
+	case DebugLevel, TraceLevel:
 		err = sw.w.Debug(sw.prefix + string(p))
 	case InfoLevel:
 		err = sw.w.Info(sw.prefix + string(p))

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -53,14 +53,14 @@ func (w *syslogTestWriter) Crit(m string) error {
 func TestSyslogWriter(t *testing.T) {
 	sw := &syslogTestWriter{}
 	log := New(SyslogLevelWriter(sw))
-	log.Trace().Msg("trace")
 	log.Debug().Msg("debug")
+	log.Trace().Msg("trace")
 	log.Info().Msg("info")
 	log.Warn().Msg("warn")
 	log.Error().Msg("error")
 	log.Log().Msg("nolevel")
 	want := []syslogEvent{
-		{"Debug", `{"level":"debug","message":"debug"}` + "\n"},
+		{"Debug", `{"level":"trace","message":"trace"}` + "\n"},
 		{"Info", `{"level":"info","message":"info"}` + "\n"},
 		{"Warning", `{"level":"warn","message":"warn"}` + "\n"},
 		{"Err", `{"level":"error","message":"error"}` + "\n"},

--- a/writer_test.go
+++ b/writer_test.go
@@ -11,13 +11,13 @@ import (
 func TestMultiSyslogWriter(t *testing.T) {
 	sw := &syslogTestWriter{}
 	log := New(MultiLevelWriter(SyslogLevelWriter(sw)))
-	log.Debug().Msg("debug")
+	log.Trace().Msg("trace")
 	log.Info().Msg("info")
 	log.Warn().Msg("warn")
 	log.Error().Msg("error")
 	log.Log().Msg("nolevel")
 	want := []syslogEvent{
-		{"Debug", `{"level":"debug","message":"debug"}` + "\n"},
+		{"Debug", `{"level":"trace","message":"trace"}` + "\n"},
 		{"Info", `{"level":"info","message":"info"}` + "\n"},
 		{"Warning", `{"level":"warn","message":"warn"}` + "\n"},
 		{"Err", `{"level":"error","message":"error"}` + "\n"},


### PR DESCRIPTION
This PR add further improvements to our version of zerolog. There are 3 main changes in this PR:

1. Added the ability to append an event to an array. This let's us nest an array of events inside an event in a clean way. The end goal of this is providing multi-line events 
2. Added a new `FormatLevelAbbreviaton` Formatter to the console logger, to customize how we want to display the abbreviations for each log level. This change respects the original implementation of zerolog
3. Swapped the `Debug` and `Trace` log severities to match our own severities, and updated the relevant tests