### PR TITLE
Added upstream version tracking file

### DIFF
--- a/Upstream.md
+++ b/Upstream.md
@@ -3,5 +3,5 @@
 This document exists to keep track of the fork and upstream versions.
 
 | Fork version | Based off upstream version |
-| ------------ | -------------------------- |
-| v1.40.0 | v.20.0 |
+|:------------:|:--------------------------:|
+| v1.40.0 | v1.20.0 |

--- a/Upstream.md
+++ b/Upstream.md
@@ -1,0 +1,7 @@
+# Upstream
+
+This document exists to keep track of the fork and upstream versions.
+
+| Fork version | Based off upstream version |
+| ------------ | -------------------------- |
+| v1.40.0 | v.20.0 |


### PR DESCRIPTION
This PR adds the version tracking file, to keep track of which version of the upstream was used for each version of the fork.

We will tag v1.40.0 based off this commit. 