### PR TITLE
Add functions to filter fields and values

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -40,6 +41,13 @@ func (c Context) FieldsWithRemove(fields map[string]interface{}, removeFields ..
 		delete(fields, removeField)
 	}
 	return c.Fields(fields)
+}
+
+// Filter is a helper function to redact a value from context
+func (c Context) Filter(filterString string) Context {
+	context := strings.Replace(decodeIfBinaryToString(c.l.context), filterString, "[FILTERED]", -1)
+	c.l.context = []byte(context)
+	return c
 }
 
 // Dict adds the field key with the dict to the logger context.

--- a/context.go
+++ b/context.go
@@ -24,6 +24,24 @@ func (c Context) Fields(fields map[string]interface{}) Context {
 	return c
 }
 
+// FieldsWithFilter is a helper function to use a map to set fields using type assertion
+// with provided fields filtered
+func (c Context) FieldsWithFilter(fields map[string]interface{}, filterFields ...string) Context {
+	for _, filterField := range filterFields {
+		fields[filterField] = "[FILTERED]"
+	}
+	return c.Fields(fields)
+}
+
+// FieldsRemoved is a helper function to use a map to set fields using type assertion
+// with provided fields removed
+func (c Context) FieldsWithRemove(fields map[string]interface{}, removeFields ...string) Context {
+	for _, removeField := range removeFields {
+		delete(fields, removeField)
+	}
+	return c.Fields(fields)
+}
+
 // Dict adds the field key with the dict to the logger context.
 func (c Context) Dict(key string, dict *Event) Context {
 	dict.buf = enc.AppendEndMarker(dict.buf)

--- a/event.go
+++ b/event.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
@@ -171,6 +172,13 @@ func (e *Event) FieldsWithRemove(fields map[string]interface{}, removeFields ...
 		delete(fields, removeField)
 	}
 	return e.Fields(fields)
+}
+
+// Filter is a helper function to filter a value from the buffer
+func (e *Event) Filter(filterString string) *Event {
+	buffer := strings.Replace(decodeIfBinaryToString(e.buf), filterString, "[FILTERED]", -1)
+	e.buf = []byte(buffer)
+	return e
 }
 
 // Dict adds the field key with a dict to the event context.

--- a/event.go
+++ b/event.go
@@ -155,6 +155,24 @@ func (e *Event) Fields(fields map[string]interface{}) *Event {
 	return e
 }
 
+// FieldsWithFilter is a helper function to use a map to set fields using type assertion
+// with provided fields filtered
+func (e *Event) FieldsWithFilter(fields map[string]interface{}, filterFields ...string) *Event {
+	for _, filterField := range filterFields {
+		fields[filterField] = "[FILTERED]"
+	}
+	return e.Fields(fields)
+}
+
+// FieldsWithRemoved is a helper function to use a map to set fields using type assertion
+// with provided fields removed
+func (e *Event) FieldsWithRemove(fields map[string]interface{}, removeFields ...string) *Event {
+	for _, removeField := range removeFields {
+		delete(fields, removeField)
+	}
+	return e.Fields(fields)
+}
+
 // Dict adds the field key with a dict to the event context.
 // Use zerolog.Dict() to create the dictionary.
 func (e *Event) Dict(key string, dict *Event) *Event {

--- a/log_test.go
+++ b/log_test.go
@@ -383,6 +383,36 @@ func TestFieldsDisabled(t *testing.T) {
 	}
 }
 
+func TestFieldsWithFilter(t *testing.T) {
+	out := &bytes.Buffer{}
+	log := New(out)
+	fields := map[string]interface{}{
+		"foo": "string foo",
+		"bar": "string bar",
+	}
+	filterField := "bar"
+	log.Log().FieldsWithFilter(fields, filterField).Msg("")
+
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"bar":"[FILTERED]","foo":"string foo"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot: %v\nwant: %v", got, want)
+	}
+}
+
+func TestFieldsWithRemove(t *testing.T) {
+	out := &bytes.Buffer{}
+	log := New(out)
+	fields := map[string]interface{}{
+		"foo": "string foo",
+		"bar": "string bar",
+	}
+	removeField := "bar"
+	log.Log().FieldsWithRemove(fields, removeField).Msg("")
+
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"foo":"string foo"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot: %v\nwant: %v", got, want)
+	}
+}
+
 func TestMsgf(t *testing.T) {
 	out := &bytes.Buffer{}
 	log := New(out)

--- a/log_test.go
+++ b/log_test.go
@@ -324,6 +324,19 @@ func TestFieldsArraySingleElement(t *testing.T) {
 	}
 }
 
+func TestFilter(t *testing.T) {
+	out := &bytes.Buffer{}
+	log := New(out)
+	log.Log().Fields(map[string]interface{}{
+		"foo": "my name is bar",
+		"baz": "hello world",
+	}).Filter("bar").Msg("")
+
+	if got, want := decodeIfBinaryToString(out.Bytes()), `{"baz":"hello world","foo":"my name is [FILTERED]"}`+"\n"; got != want {
+		t.Errorf("invalid log output:\ngot: %v\nwant: %v", got, want)
+	}
+}
+
 func TestFieldsArrayMultipleElement(t *testing.T) {
 	out := &bytes.Buffer{}
 	log := New(out)


### PR DESCRIPTION
## What is the purpose of this change?
This adds 3 new functions to help filter and remove the logger output.
- `FieldsWithFilter` - takes a map of keys and values along with a spatted slice of strings of key names which should be filtered. The function overwrites the values with `[FILTERED]` for the given fields. It then delegates to the `Fields` function.
- `FieldsWithRemove` - takes a map of keys and values along with a spatted slice of strings of key names which should be remove. The function deletes the key and values. It then delegates to the `Fields` function.
- `Filter` - takes a string, which should be filtered out from the log buffer. This replaces the given string with `[FILTERED]` in the buffer.

## Thought process
I was looking to keep the same interface used for the `Fields` function, so it can be utilized in the same manner. `FieldsWithFilter` or `FieldsWithRemove` should be used instead of `Fields` to filter out the whole field for the json log.

The `Filter` function again uses the same interface as other functions on logger and is used for filtering out parts of the value in the log buffer. Since the log buffer is just a string and not a json object or any other struct, a string replacement is done for all instances of the given string to filter.

I didn't think a `Remove` function was required as removing parts of values in the log may make the output more misleading and confusing.
